### PR TITLE
Add a layout for interactive tutorials

### DIFF
--- a/src/layouts/interactive.hbs
+++ b/src/layouts/interactive.hbs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+{{> head-prelude}}
+    <title>Hazelcast Documentation</title>
+    {{#with page.canonicalUrl}}
+    <link rel="canonical" href="{{this}}">
+    {{/with}}
+{{> head-styles}}
+{{> head-meta}}
+{{> head-scripts}}
+<script src="https://katacoda.com/embed.js"></script>
+{{> head-icons}}
+  </head>
+  <body>
+  {{#with site.keys.googleAnalytics}}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{this}}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {{/with}}
+{{> header}}
+{{#with page.attributes.scenario}}
+<div data-katacoda-id="hazelcast-code/{{this}}"
+  id="katacoda-scenario-1"
+  style="height:100%;">
+</div>
+{{/with}}
+{{> footer}}
+  </body>
+</html>


### PR DESCRIPTION
Added a layout that you can use for displaying interactive [Katacoda](https://www.katacoda.com/) tutorials.

To use this layout on a page, you need to add the following attributes:

```
:page-layout: interactive
:page-scenario: {name-of-your-katacoda-scenario}
```

When Antora processes the page, it will add the contents of the `page-scenario` atttribute to the Katacoda HTML in the `layouts/interactive.hbs` file.

For details about Katacoda embedded, see the [Katacoda docs](https://www.katacoda.community/embed.html).