### PR TITLE
Enable scripts to be added by macros

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -253,3 +253,6 @@
   });
 </script>
 {{/if}}
+{{#if page.attributes.content-scripts}}
+{{{page.attributes.content-scripts}}}
+{{/if}}


### PR DESCRIPTION
This PR allows the UI to inject scripts into pages that include the `page-content-scripts` attribute.

This attribute is created in the Swagger UI macro here: https://github.com/hazelcast/management-center-docs/blob/9cc743d94437c4dae953d7c8c6ea2c516ed6c7ab/lib/swagger-ui-block-macro.js#L35