### PR TITLE
Remove unused check for 404

### DIFF
--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -1332,9 +1332,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{this}}');</script>
 <!-- End Google Tag Manager -->
-{{#contains 'Page Not Found' @root.page.title}}
-<!-- Report the 404 event -->
-{{/contains}}
 {{/with}}
 {{> head-prelude}}
 {{> head-title}}


### PR DESCRIPTION
This block was causing the site to complain if a page does not contain a level 1 heading. Although this might seem useful, the error does not report the pages that are missing the heading.