### PR TITLE
Reorder components

### DIFF
--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -191,6 +191,11 @@ html.is-clipped--nav {
   display: none;
 }
 
+.nav-panel-explore .component.home {
+  text-align: right;
+  margin-top: 15px !important;
+}
+
 .nav-panel-explore .component {
   display: block;
 }

--- a/src/partials/nav-explore.hbs
+++ b/src/partials/nav-explore.hbs
@@ -11,57 +11,62 @@
     </div>
   {{/if}}
   <ul class="components">
-    <li style="list-style: none;">Select a different product or version of documentation:</li>
+    <li style="list-style: none;">Select a different product or version:</li>
     </br>
     {{#each site.components}}
-      <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
-        {{#if (and (not-eq this.name 'home') (not-eq this.name 'cloud'))}}
-          <span class="title">{{{./title}}} <a class="more-versions">See all versions</a><a class="fewer-versions">See fewer versions</a></span>
-        {{else}}
-          <span class="title">{{{./title}}}</span>
-        {{/if}}
-        <ul class="versions">
-          {{#if (eq this @root.page.component)}}
-            {{#if (and (not-eq this.name 'home') (not-eq this.name 'cloud'))}}
-              {{#each ./versions}}
-                {{#if (lte @index 6)}}
-                  <li class="version
+      {{#if (not-eq this.name 'home')}}
+        <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
+          {{#if (and (not-eq this.name 'home') (not-eq this.name 'cloud'))}}
+            <span class="title">{{{./title}}} <a class="more-versions">See all versions</a><a class="fewer-versions">See fewer versions</a></span>
+          {{else}}
+            <span class="title">{{{./title}}}</span>
+          {{/if}}
+          <ul class="versions">
+            {{#if (eq this @root.page.component)}}
+              {{#if (and (not-eq this.name 'home') (not-eq this.name 'cloud'))}}
+                {{#each ./versions}}
+                  {{#if (lte @index 6)}}
+                    <li class="version
+                      {{~#if (and (eq .. @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
+                      {{~#if (eq this ../latest)}} is-latest{{/if}}">
+                      <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+                    </li>
+                  {{else}}
+                    <li class="version hidden">
+                      <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+                    </li>
+                  {{/if}}
+                {{/each}}
+              {{/if}}
+            {{/if}}
+            {{#if (or (eq this.name 'home') (eq this.name 'cloud'))}}
+              <li class="version
+                {{~#if (eq this ../latest)}} is-latest{{/if}}">
+                {{#if (eq this.name 'cloud')}}
+                  <a href="{{{relativize ./url}}}">Go to Cloud Docs</a>
+              </li>
+                {{/if}}
+            {{else}}
+              {{#if (not-eq this @root.page.component)}}
+                {{#each ./versions}}
+                  <li class="version hidden
                     {{~#if (and (eq .. @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
                     {{~#if (eq this ../latest)}} is-latest{{/if}}">
                     <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
                   </li>
-                {{else}}
-                  <li class="version hidden">
-                    <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
-                  </li>
+                {{/each}}
                 {{/if}}
-              {{/each}}
             {{/if}}
-          {{/if}}
-          {{#if (or (eq this.name 'home') (eq this.name 'cloud'))}}
-            <li class="version
-              {{~#if (eq this ../latest)}} is-latest{{/if}}">
-              {{#if (eq this.name 'cloud')}}
-                <a href="{{{relativize ./url}}}">Go to Cloud Docs</a>
-            </li>
-              {{/if}}
-              {{#if (eq this.name 'home')}}
-              <a href="{{{relativize ./url}}}">Back to Home</a>
-            </li>
-              {{/if}}
-          {{else}}
-            {{#if (not-eq this @root.page.component)}}
-              {{#each ./versions}}
-                <li class="version hidden
-                  {{~#if (and (eq .. @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
-                  {{~#if (eq this ../latest)}} is-latest{{/if}}">
-                  <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
-                </li>
-              {{/each}}
-              {{/if}}
-          {{/if}}
-        </ul>
-      </li>
+          </ul>
+        </li>
+      {{/if}}
+    {{/each}}
+    {{#each site.components}}
+      {{#if (eq this.name 'home')}}
+        <li class="component home">
+        <a href="{{{relativize ./url}}}">Back to Home</a>
+        </li>
+      {{/if}}
     {{/each}}
   </ul>
 </div>


### PR DESCRIPTION
The *Back to home* button in the product selector appeared in the middle of actual products. This was distracting and disorganized. This PR moves this link below all the products and offsets it for a better UX.