### PR TITLE
Update product list in the heading

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -15,16 +15,13 @@
           <a class="navbar-link" href="#" onclick="return false">Products</a>
           <div class="navbar-dropdown">
             <a class="navbar-item" href="https://hazelcast.com/products/cloud/" onclick="window.open(this.href,'_blank');return false;">Hazelcast Cloud</a>
-            <a class="navbar-item" href="https://hazelcast.com/products/imdg/" onclick="window.open(this.href,'_blank');return false;">Hazelcast IMDG</a>
-            <a class="navbar-item" href="https://hazelcast.com/products/jet/" onclick="window.open(this.href,'_blank');return false;">Hazelcast Jet</a>
-          </div>
+            <a class="navbar-item" href="https://hazelcast.com/products/hazelcast-platform/" onclick="window.open(this.href,'_blank');return false;">Hazelcast Platform</a>          </div>
         </div>
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link" href="#" onclick="return false">Learn</a>
           <div class="navbar-dropdown">
             <a class="navbar-item" href="{{{siteRootPath}}}/home/index.html">Docs</a>
             <a class="navbar-item" href="https://training.hazelcast.com/" onclick="window.open(this.href,'_blank');return false;">Online Training</a>
-            <a class="navbar-item" href="https://hazelcast.com/resources/mastering-hazelcast/" onclick="window.open(this.href,'_blank');return false;"> Mastering Hazelcast eBook</a>
             <a class="navbar-item" href="https://hazelcast.com/resources/" onclick="window.open(this.href,'_blank');return false;">Search All Resources</a>
           </div>
         </div>


### PR DESCRIPTION
The product list included our legacy IMDG and Jet offerings. This PR removes those products from the product list and adds Hazelcast Platform. It also removes the Mastering Hazelcast eBook because it is outdated (only applies to version 3.9 of IMDG).