### PR TITLE
Fix redirect script

### DIFF
--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -1,5 +1,5 @@
 {{#if (eq page.component.name 'imdg')}}
-{{#contains 'index' page.url}}
+{{#contains 'Hazelcast IMDG Reference Manual' page.title}}
 <script>
   (function () {
     var url = '';
@@ -1065,7 +1065,7 @@
 {{/contains}}
 {{/if}}
 {{#if (eq page.component.name 'management-center')}}
-{{#contains 'index' page.url}}
+{{#contains 'Hazelcast Management Center' page.title}}
 <script>
 (function () {
   var url = '';


### PR DESCRIPTION
Since we started using pretty URLs with Netlify, the redirect script was no longer being inserted into the index pages because `index.html` is redirected to `/`.

This PR fixes the redirect script so that it is inserted into the correct page by page title.