### PR TITLE
Customize product selector for Turbine docs

### DIFF
--- a/src/partials/nav-explore.hbs
+++ b/src/partials/nav-explore.hbs
@@ -1,5 +1,5 @@
 <div class="nav-panel-explore{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore">
-  {{#if page.component}}
+  {{#if (and page.component (not-eq page.component.name 'turbine'))}}
     <div class="context">
       <span class="title">{{page.component.title}}</span>
       {{#if (eq page.component.name 'cloud')}}
@@ -14,7 +14,7 @@
     <li style="list-style: none;">Select a different product or version:</li>
     </br>
     {{#each site.components}}
-      {{#if (not-eq this.name 'home')}}
+      {{#if (and (not-eq this.name 'home') (not-eq this.name 'turbine'))}}
         <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
           {{#if (and (not-eq this.name 'home') (not-eq this.name 'cloud'))}}
             <span class="title">{{{./title}}} <a class="more-versions">See all versions</a><a class="fewer-versions">See fewer versions</a></span>

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -1,6 +1,10 @@
 <div class="nav-container"{{#if page.component}} data-component="{{page.component.name}}" data-version="{{page.version}}"{{/if}}>
   <aside class="nav">
-    {{> nav-explore}}
+    {{#if (eq page.component.name 'turbine')}}
+      {{> turbine-nav-explore}}
+    {{else}}
+      {{> nav-explore}}
+    {{/if}}
     <div class="panels">
 {{> nav-menu}}
     </div>

--- a/src/partials/turbine-nav-explore.hbs
+++ b/src/partials/turbine-nav-explore.hbs
@@ -1,0 +1,38 @@
+<div class="nav-panel-explore{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore">
+  {{#if page.component}}
+    <div class="context">
+      <span class="title">{{page.component.title}}</span>
+        <span class="version">{{page.componentVersion.displayVersion}}</span>
+      <button class="nav-item-toggle nav-explore-toggle"></button>
+    </div>
+  {{/if}}
+  <ul class="components">
+    <li style="list-style: none;">Select a product version:</li>
+    </br>
+    <li class="component is-current">
+        <span class="title"><a class="more-versions">See all versions</a><a class="fewer-versions">See fewer versions</a></span>
+      <ul class="versions">
+        {{#each page.versions}}
+          {{#if (lte @index 6)}}
+            <li class="version
+              {{~#if (eq this page.componentVersion)}} is-current{{/if~}}
+              {{~#if (eq this ../latest)}} is-latest{{/if}}">
+              <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+              </li>
+            {{else}}
+              <li class="version hidden">
+                <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+            </li>
+          {{/if}}
+        {{/each}}
+      </ul>
+    </li>
+    {{#each site.components}}
+      {{#if (eq this.name 'home')}}
+        <li class="component home">
+        <a href="{{{relativize ./url}}}">Back to Home</a>
+        </li>
+      {{/if}}
+    {{/each}}
+  </ul>
+</div>


### PR DESCRIPTION
We will be hosting the Turbine docs at docs.hazelcast.com/turbine, but we do not want to display Turbine as an option in the product selector. This PR customizes the nav-explore component for Turbine so that it is hidden from the product selector when viewing docs for other Hazelcast products.