### PR TITLE
Add enterprise labels to pages

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -14,6 +14,16 @@
   font-size: 2em;
 }
 
+.doc > h1.page.enterprise::after {
+  content: 'Enterprise';
+  background: var(--primary-dark);
+  padding: 2px;
+  margin-left: 5px;
+  color: white;
+  border-radius: 3px;
+  font-size: small;
+}
+
 .doc details {
   margin-top: 15px;
   cursor: pointer;

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -18,10 +18,11 @@
   content: 'Enterprise';
   background: var(--primary-dark);
   padding: 2px;
-  margin-left: 5px;
+  margin-left: 15px;
   color: white;
   border-radius: 3px;
-  font-size: small;
+  font-size: medium;
+  vertical-align: middle;
 }
 
 .doc details {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -14,6 +14,15 @@
   font-size: 2em;
 }
 
+strong.enterprise {
+  background: var(--primary-dark);
+  padding: 2px;
+  color: white;
+  border-radius: 3px;
+  font-size: medium;
+  vertical-align: middle;
+}
+
 .doc > h1.page.enterprise::after {
   content: 'Enterprise';
   background: var(--primary-dark);

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -172,7 +172,7 @@ html.is-clipped--nav {
 }
 
 .nav-link.enterprise::after {
-  content: ' Enterprise';
+  content: 'Enterprise';
   background: var(--primary-dark);
   padding: 2px;
   margin-left: 5px;

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -171,6 +171,16 @@ html.is-clipped--nav {
   color: var(--primary);
 }
 
+.nav-link.enterprise::after {
+  content: ' Enterprise';
+  background: var(--primary-dark);
+  padding: 2px;
+  margin-left: 5px;
+  color: white;
+  border-radius: 3px;
+  font-size: small;
+}
+
 .nav-panel-explore {
   display: flex;
   flex-direction: column;

--- a/src/helpers/is-enterprise.js
+++ b/src/helpers/is-enterprise.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = (navUrl, { data: { root } }) => {
+  const { contentCatalog, page } = root
+  const pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
+  for (let i = 0; i < pages.length; i++) {
+    if (pages[i].pub.url === navUrl &&
+      pages[i].asciidoc.attributes['page-enterprise'] === 'true') {
+      return true
+    }
+  }
+}

--- a/src/helpers/is-enterprise.js
+++ b/src/helpers/is-enterprise.js
@@ -1,8 +1,8 @@
 'use strict'
 
-module.exports = (navUrl, { data: { root } }) => {
-  const { contentCatalog, page } = root
-  const pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
+module.exports = (navUrl, component, { data: { root } }) => {
+  const { contentCatalog /*,page*/ } = root
+  const pages = contentCatalog.findBy({ component: /*page.component.name*/component, family: 'page' })
   for (let i = 0; i < pages.length; i++) {
     if (pages[i].pub.url === navUrl &&
       pages[i].asciidoc.attributes['page-enterprise'] === 'true') {

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -34,7 +34,7 @@ If you entered the URL of this page manually, please double check that you enter
 {{> breadcrumbs}}
 {{>nav-toggle}}
 {{#with page.title}}
-<h1 class="page">{{{this}}}</h1>
+<h1 class="page {{~#if (eq @root.page.attributes.enterprise 'true')}} enterprise{{/if}}">{{{this}}}</h1>
 {{/with}}
 {{#if page.attributes.api-reference}}
 <div style="padding-top: 5px;">

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -34,7 +34,7 @@ If you entered the URL of this page manually, please double check that you enter
 {{> breadcrumbs}}
 {{>nav-toggle}}
 {{#with page.title}}
-<h1 class="page {{~#if (eq @root.page.attributes.enterprise 'true')}} enterprise{{/if}}">{{{this}}}</h1>
+<h1 class="page {{~#if (and (eq @root.page.attributes.enterprise 'true') (eq @root.page.component.name 'management-center'))}} enterprise{{/if}}">{{{this}}}</h1>
 {{/with}}
 {{#if page.attributes.api-reference}}
 <div style="padding-top: 5px;">

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -5,7 +5,8 @@
     {{#if ./content}}
     {{#if ./url}}
     <a class="nav-link
-    <!--Labels Enterprise content in sidenav{{~#if (is-enterprise ./url)}} enterprise{{/if}}-->
+    <!--Labels Enterprise content in sidenav (only MC for now) -->
+    {{~#if (is-enterprise ./url 'management-center')}} enterprise{{/if}}
     " href="
       {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
       {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -4,7 +4,7 @@
   <li class="nav-item{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
     {{#if ./content}}
     {{#if ./url}}
-    <a class="nav-link" href="
+    <a class="nav-link {{~#if (is-enterprise ./url)}} enterprise{{/if}}" href="
       {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
       {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
     {{#if ./items.length}}

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -4,7 +4,9 @@
   <li class="nav-item{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
     {{#if ./content}}
     {{#if ./url}}
-    <a class="nav-link {{~#if (is-enterprise ./url)}} enterprise{{/if}}" href="
+    <a class="nav-link
+    <!--Labels Enterprise content in sidenav{{~#if (is-enterprise ./url)}} enterprise{{/if}}-->
+    " href="
       {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
       {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
     {{#if ./items.length}}


### PR DESCRIPTION
This PR adds a consistent approach to letting users know that a page applies only to Enterprise.

Labels are added, depending on the page metadata. If a page includes the `:page-enterprise: true` attribute, the UI will add a label to the sidenav entry.

PoC sidenav:
![image](https://user-images.githubusercontent.com/45230295/145976849-8212f321-c765-4ce9-87a2-4f1b7a36fdc2.png)

PoC page title:
![image](https://user-images.githubusercontent.com/45230295/146234887-d061ec60-bf71-448f-a970-60b53f76b3e7.png)

It may make the sidenav a bit messy if we include the labels for all Enterprise pages. Maybe we should consider only using it for the page title.

TODO:

- [x] Discuss style with Pawel
- [x] Add labels to title
- [ ] Make sure all relevant pages include the correct metadata.