### PR TITLE
Improve labelling

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -16,9 +16,10 @@
 
 strong.enterprise {
   background: var(--primary-dark);
-  padding: 2px;
+  padding: 4px;
   color: white;
-  border-radius: 3px;
+  border-radius: 10px;
+  font-weight: normal;
   font-size: medium;
   vertical-align: middle;
 }
@@ -26,12 +27,36 @@ strong.enterprise {
 .doc > h1.page.enterprise::after {
   content: 'Enterprise';
   background: var(--primary-dark);
-  padding: 2px;
+  padding: 4px;
   margin-left: 15px;
   color: white;
-  border-radius: 3px;
+  border-radius: 10px;
   font-size: medium;
   vertical-align: middle;
+}
+
+.doc > h1.page.beta::after {
+  content: 'Beta';
+  border-radius: 10px;
+  border: none;
+  font-size: medium;
+  vertical-align: middle;
+  color: #041a3b;
+  background: var(--success-light);
+  padding: 4px;
+  margin-left: 15px;
+}
+
+.doc > h1.page.enterprise.beta::after {
+  content: 'Enterprise Beta';
+  border-radius: 10px;
+  border: none;
+  font-size: medium;
+  vertical-align: middle;
+  color: #041a3b;
+  background: var(--success-light);
+  padding: 4px;
+  margin-left: 15px;
 }
 
 .doc details {

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -174,11 +174,34 @@ html.is-clipped--nav {
 .nav-link.enterprise::after {
   content: 'Enterprise';
   background: var(--primary-dark);
-  padding: 2px;
+  padding: 4px;
   margin-left: 5px;
   color: white;
-  border-radius: 3px;
-  font-size: small;
+  border-radius: 10px;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
+.nav-link.beta::after {
+  content: 'Beta';
+  color: #041a3b;
+  background: var(--success-light);
+  padding: 4px;
+  margin-left: 5px;
+  border-radius: 10px;
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
+.nav-link.enterprise.beta::after {
+  content: 'Enterprise Beta';
+  color: #041a3b;
+  background: var(--success-light);
+  padding: 4px;
+  margin-left: 5px;
+  border-radius: 10px;
+  font-size: 0.7em;
+  vertical-align: middle;
 }
 
 .nav-panel-explore {

--- a/src/helpers/is-beta.js
+++ b/src/helpers/is-beta.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = (navUrl, { data: { root } }) => {
+  const { contentCatalog, page } = root
+  var pages = contentCatalog.navGroup
+  if (!pages) {
+    pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
+    contentCatalog.navGroup = pages
+  }
+  for (let i = 0; i < pages.length; i++) {
+    if (pages[i].pub.url === navUrl &&
+      pages[i].asciidoc.attributes['page-beta'] === 'true') {
+      return true
+    }
+  }
+}

--- a/src/helpers/is-enterprise.js
+++ b/src/helpers/is-enterprise.js
@@ -1,8 +1,12 @@
 'use strict'
 
-module.exports = (navUrl, component, { data: { root } }) => {
-  const { contentCatalog /*,page*/ } = root
-  const pages = contentCatalog.findBy({ component: /*page.component.name*/component, family: 'page' })
+module.exports = (navUrl, { data: { root } }) => {
+  const { contentCatalog, page } = root
+  var pages = contentCatalog.navGroup
+  if (!pages) {
+    pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
+    contentCatalog.navGroup = pages
+  }
   for (let i = 0; i < pages.length; i++) {
     if (pages[i].pub.url === navUrl &&
       pages[i].asciidoc.attributes['page-enterprise'] === 'true') {

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -34,7 +34,7 @@ If you entered the URL of this page manually, please double check that you enter
 {{> breadcrumbs}}
 {{>nav-toggle}}
 {{#with page.title}}
-<h1 class="page {{~#if (and (eq @root.page.attributes.enterprise 'true') (eq @root.page.component.name 'management-center'))}} enterprise{{/if}}">{{{this}}}</h1>
+<h1 class="page {{~#if (and (eq @root.page.attributes.enterprise 'true') (eq @root.page.component.name 'management-center'))}} enterprise{{/if}} {{~#if (eq @root.page.attributes.beta 'true')}} beta{{/if}}">{{{this}}}</h1>
 {{/with}}
 {{#if page.attributes.api-reference}}
 <div style="padding-top: 5px;">

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -4,18 +4,13 @@
   <li class="nav-item{{#if (eq ./url @root.page.url)}} is-current-page{{/if}}" data-depth="{{or ../level 0}}">
     {{#if ./content}}
     {{#if ./url}}
-    {{#if (eq @root.page.component.name 'management-center')}}
     <a class="nav-link
     <!--Labels Enterprise content in sidenav (only MC for now) -->
-    {{~#if (is-enterprise ./url 'management-center')}} enterprise{{/if}}
+    {{~#if (is-enterprise ./url)}} enterprise{{/if}}
+    {{~#if (is-beta ./url)}} beta{{/if}}
     " href="
       {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
       {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
-    {{else}}
-    <a class="nav-link" href="
-      {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
-      {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>
-    {{/if}}
     {{#if ./items.length}}
     <button class="nav-item-toggle"></button>
     {{/if}}


### PR DESCRIPTION
Cached labelling results on the `contentCatalog` object for faster processing: Before, Antora was having to do a lookup for every page, which slowed down the build so much that Netlify would hang.

Added support for beta tags and adjusted the styles to conform to the HIVE design.