### PR TITLE
Fix bug in sidenav label checker

### DIFF
--- a/src/helpers/is-beta.js
+++ b/src/helpers/is-beta.js
@@ -3,9 +3,12 @@
 module.exports = (navUrl, { data: { root } }) => {
   const { contentCatalog, page } = root
   var pages = contentCatalog.navGroup
-  if (!pages) {
+  var cp = contentCatalog.cp
+  if (!pages || cp !== page.component.name) {
     pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
     contentCatalog.navGroup = pages
+    contentCatalog.cp = page.component.name
+    console.log(contentCatalog.cp)
   }
   for (let i = 0; i < pages.length; i++) {
     if (pages[i].pub.url === navUrl &&

--- a/src/helpers/is-enterprise.js
+++ b/src/helpers/is-enterprise.js
@@ -3,9 +3,12 @@
 module.exports = (navUrl, { data: { root } }) => {
   const { contentCatalog, page } = root
   var pages = contentCatalog.navGroup
-  if (!pages) {
+  var cp = contentCatalog.cp
+  if (!pages || cp !== page.component.name) {
     pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
     contentCatalog.navGroup = pages
+    contentCatalog.cp = page.component.name
+    console.log(contentCatalog.cp)
   }
   for (let i = 0; i < pages.length; i++) {
     if (pages[i].pub.url === navUrl &&

--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -5,10 +5,8 @@
         {{#if ./content}}
           {{#if ./url}}
             <a class="nav-link
-            {{#if (eq @root.page.component.name 'management-center')}}
               {{~#if (is-enterprise ./url)}} enterprise{{/if}}
               {{~#if (is-beta ./url)}} beta{{/if}}
-            {{/if}}
             " href="
             {{~#if (eq ./urlType 'internal')}}{{{relativize ./url}}}
             {{~else}}{{{./url}}}{{~/if}}">{{{./content}}}</a>


### PR DESCRIPTION
Cache the component as well as the nav pages to allow the script to fetch pages for each component.

Before, the script was caching pages for a single component and other component pages were not being checked.