### PR TITLE
DOCS-317 Fix code elements showing in front of banner

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -30,6 +30,7 @@
   position: sticky;
   top: 50px;
   justify-content: flex-start;
+  z-index: 1;
 }
 
 .article-banner .prerelease .fa.fa-info {


### PR DESCRIPTION
Code snippets were showing in front of the pre-release banner. 