### PR TITLE
DOCS-554 Remove WAN Replication link

### DIFF
--- a/src/partials/body-home.hbs
+++ b/src/partials/body-home.hbs
@@ -51,7 +51,7 @@
 										<a href="{{{siteRootPath}}}/cloud/developer-guide">Developer Guide</a>
 									</li>
 									<li class="section-content-list-item">
-										<a href="{{{siteRootPath}}}/cloud/wan-replication">Replicate Data Between Clusters</a>
+										<a href="{{{siteRootPath}}}/cloud/management-center">Monitor Your Clusters</a>
 									</li>
 								</ul>
 							</div>


### PR DESCRIPTION
WAN replication docs are being removed from cloud docs so this PR removes the link to them.