### PR TITLE
DOCS-806: add Clarity snippet to home and default

### DIFF
--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -2,6 +2,15 @@
 <html lang="en">
   <head>
 {{> head defaultPageTitle='Hazelcast'}}
+  <!-- Clarity snippet -->
+  <script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "l8c076m4u9");
+  </script>
+  <!-- End Clarity snippet -->
   </head>
   <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
   {{#with site.keys.googleAnalytics}}

--- a/src/layouts/home.hbs
+++ b/src/layouts/home.hbs
@@ -10,6 +10,15 @@
 {{> head-meta}}
 {{> head-scripts}}
 {{> head-icons}}
+  <!-- Clarity snippet -->
+  <script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "l8c076m4u9");
+  </script>
+  <!-- End Clarity snippet -->
   </head>
   <body>
   {{#with site.keys.googleAnalytics}}


### PR DESCRIPTION
This uses the manual tracking code only.

I did test with both manual tracking code and GTM snippet and got live users i.e. data on Clarity. Currently, Clarity is not showing live users but I'm hoping this is due to running locally with manual snippet. If not then we need the GTM snippet after all (think the GTM config needs looks at generally as I didn't think it was correctly set up).