### PR TITLE
DOC-36: add suffix to page title

### DIFF
--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,1 +1,1 @@
-    <title>{{{detag (or page.title defaultPageTitle)}}}</title>
+    <title>{{{detag (or page.title defaultPageTitle)}}} | Hazelcast Documentation</title>


### PR DESCRIPTION
Adds a suffix to page title so every page indicates it is a docs page