### PR TITLE
Adds search capability for CLC and Operator docs on the Home Page.

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -92,6 +92,8 @@
       [["tags:hazelcast-{{site.components.hazelcast.latest.version}}", 
       "tags:management-center-{{site.components.management-center.latest.version}}", 
       "tags:imdg-{{site.components.imdg.latest.version}}", 
+      "tags:imdg-{{site.components.clc.latest.version}}", 
+      "tags:imdg-{{site.components.operator.latest.version}}", 
       "tags:cloud"]] },
   });
   </script>


### PR DESCRIPTION
if I read the following code correctly.

https://github.com/hazelcast/hazelcast-docs-ui/blob/master/src/helpers/latest-page-url.js