### PR TITLE
Fix CLC/Operator Algolia tags

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -92,8 +92,8 @@
       [["tags:hazelcast-{{site.components.hazelcast.latest.version}}", 
       "tags:management-center-{{site.components.management-center.latest.version}}", 
       "tags:imdg-{{site.components.imdg.latest.version}}", 
-      "tags:imdg-{{site.components.clc.latest.version}}", 
-      "tags:imdg-{{site.components.operator.latest.version}}", 
+      "tags:clc-{{site.components.clc.latest.version}}", 
+      "tags:operator-{{site.components.operator.latest.version}}", 
       "tags:cloud"]] },
   });
   </script>


### PR DESCRIPTION
Allow CLC and Operator docs to be searchable on the Home page.