### PR TITLE
Rename `Open Source` to `Community Edition`

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -16,7 +16,7 @@
       <p>Useful Links</p>
       <ul>
         <li><a href="https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-cli">Quickstart</a></li>
-        <li><a href="https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast">Installing Hazelcast Open Source</a></li>
+        <li><a href="https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast">Installing Hazelcast Community Edition</a></li>
         <li><a href="https://docs.hazelcast.com/hazelcast/latest/configuration/understanding-configuration">Hazelcast Configuration</a></li>
       </ul>
     </div>

--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -14,7 +14,7 @@
       with the stream processing power of Jet. Find out more in our <a href="https://docs.hazelcast.com/hazelcast/5.3/"><u>Platform documentation</u></a>.</p>
     <p>The following topics are a good place to start:</p>
     <ul>
-      <li><a href="https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast"><u>Install the Open Source Edition of Hazelcast Platform</u></a></li>
+      <li><a href="https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast"><u>Install the Community Edition of Hazelcast Platform</u></a></li>
       <li><a href="https://docs.hazelcast.com/hazelcast/latest/sql/learn-sql.html"><u>Use the improved SQL shell to query Kafka topics in real time</u></a></li>
       <li><a href="https://docs.hazelcast.com/hazelcast/latest/migrate/migration-tool-imdg.html"><u>Migrate from IMDG to Hazelcast Platform</u></a></li>
     </ul>


### PR DESCRIPTION
[Some pages](https://docs.hazelcast.com/imdg/4.2/installation/installing-using-cli) still show the old `Open Source` naming.

![image](https://github.com/user-attachments/assets/8175f5a5-4d2b-4293-9086-8ffbb08ad9fd)

Ideally [this should be externalised](https://github.com/hazelcast/hz-docs/pull/1072), but I have not done this.