### PR TITLE
Skip redirects download

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "bundle": "gulp bundle",
     "build": "npm run bundle && load-docs-ui-playbook && antora --to-dir docs --fetch global-antora-playbook.yml && cp _redirects docs",
-    "build-local": "npm run bundle && load-docs-ui-playbook --skip-private-repos && antora --to-dir docs --fetch global-antora-playbook.yml",
+    "build-local": "npm run bundle && load-docs-ui-playbook --skip-private-repos --skip-redirects-download && antora --to-dir docs --fetch global-antora-playbook.yml",
     "serve": "serve docs",
     "expose": "ngrok http 3000",
     "dev": "gulp preview"


### PR DESCRIPTION
The flag makes the script to skip the download of the _[redirects](https://github.com/hazelcast/hazelcast-docs/blob/main/_redirects) file when creating a global build from non-hazelcast-docs repos

For the production build we need that file, but it is useless for local build