### PR TITLE
DOC-533: Re-enable EE labelling for Platform nav

### DIFF
--- a/src/partials/nav-tree.hbs
+++ b/src/partials/nav-tree.hbs
@@ -5,7 +5,7 @@
         {{#if ./content}}
           {{#if ./url}}
             <a class="nav-link
-             {{#if (and (eq @root.page.component.name 'management-center') (eq @root.page.component.name 'hazelcast')) }}
+             {{#if (or (eq @root.page.component.name 'management-center') (eq @root.page.component.name 'hazelcast')) }}
               {{~#if (is-enterprise ./url)}} enterprise{{/if}}
               {{/if}}
               {{~#if (is-beta ./url)}} beta{{/if}}


### PR DESCRIPTION
The EE labelling was removed for Platform in legacy PR due to too many labels - let's see what it looks like in preview with the updated nav.