### PR TITLE
Remove explicit cURL `POST`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,4 +80,4 @@ jobs:
     needs: release
     steps:
       - name: Trigger build
-        run: curl -X POST -d {} https://api.netlify.com/build_hooks/673db01c3496b5513b30c92e
+        run: curl -d {} https://api.netlify.com/build_hooks/673db01c3496b5513b30c92e


### PR DESCRIPTION
When executed with `verbose`, cURL logs:
> Note: Unnecessary use of -X or --request, POST is already inferred.

[The `-d`/`--data` flag sends data via `POST`](https://curl.se/docs/manpage.html#-d) so specifying `POST` _as well_ is redundant.